### PR TITLE
[JENKINS-13376] Customize Label Text

### DIFF
--- a/src/main/java/hudson/plugins/labeledgroupedtests/LabeledTestGroupConfiguration.java
+++ b/src/main/java/hudson/plugins/labeledgroupedtests/LabeledTestGroupConfiguration.java
@@ -28,11 +28,9 @@ import hudson.Util;
 import hudson.model.Descriptor;
 import hudson.model.Hudson;
 import hudson.tasks.junit.JUnitParser;
-import hudson.util.FormValidation;
 import hudson.model.Describable;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.QueryParameter;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -104,15 +102,6 @@ public class LabeledTestGroupConfiguration implements Describable<LabeledTestGro
         @Override
         public String getDisplayName() {
             return StringUtils.EMPTY;
-        }
-
-        public FormValidation doCheckLabel(@QueryParameter String value){
-            if(VALID_LABEL.matcher(value).matches()){
-                return FormValidation.ok();
-            }
-            else{
-                return FormValidation.error("Label must be a non-empty, alphanumeric string.");
-            }
         }
 
     }

--- a/src/main/java/hudson/plugins/labeledgroupedtests/LabeledTestResultGroupPublisher.java
+++ b/src/main/java/hudson/plugins/labeledgroupedtests/LabeledTestResultGroupPublisher.java
@@ -37,10 +37,8 @@ import hudson.tasks.Recorder;
 import hudson.tasks.test.TestResult;
 import hudson.tasks.test.TestResultParser;
 import hudson.tasks.test.TestResultAggregator;
-import hudson.util.FormValidation;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
 import java.io.IOException;
@@ -108,23 +106,6 @@ public class LabeledTestResultGroupPublisher extends Recorder implements Seriali
 
     public void setConfigs(List<LabeledTestGroupConfiguration> configs) {
         this.configs = configs;
-    }
-
-    public FormValidation doCheckConfigs(@QueryParameter List<LabeledTestGroupConfiguration> value){
-        int n = value.size();
-        List<LabeledTestGroupConfiguration> sortedConfigs = new ArrayList<LabeledTestGroupConfiguration>(n);
-        Collections.copy(sortedConfigs, value);
-        Collections.sort(sortedConfigs);
-        for(int i = 0; i < n-1; i++){
-            String configA = sortedConfigs.get(i).getLabel();
-            String configB = sortedConfigs.get(i+1).getLabel();
-            if(configA.equals(configB)){
-                return FormValidation.error(
-                        (new StringBuilder("Cannot have two labeled test group configurations with same name: "))
-                                .append(configA).toString());
-            }
-        }
-        return FormValidation.ok();
     }
 
     @Override


### PR DESCRIPTION
Tested using mvn clean install; passes all tests. In addition, I configured a job with the "selectable" labels. When loading the SAME JOB with the updated plugin, all label names remained the same.

Additional features:
- Sorts group configurations by label name in the job.
- Does Form Validation to make sure no two have the same labels, also labels are alphanumeric characters.
  Minor bugs introduced:
- Re-orders test groups in the configuration
- Form Validation is not enforced in all Hudson versions
