### PR TITLE
[JENKINS-13376] Free the test group label!

### DIFF
--- a/src/main/java/hudson/plugins/labeledgroupedtests/LabeledTestResultGroupPublisher.java
+++ b/src/main/java/hudson/plugins/labeledgroupedtests/LabeledTestResultGroupPublisher.java
@@ -86,10 +86,6 @@ public class LabeledTestResultGroupPublisher extends Recorder implements Seriali
         return testResultParsers;
     }
 
-    public static List<String> getPhases() {
-        return Arrays.asList("unit", "smoke", "regression", "integration", "special", "misc");
-    }
-
     public void debugPrint() {
         for (LabeledTestGroupConfiguration config: configs) {
             LOGGER.info("got config: " + config.toString());

--- a/src/main/resources/hudson/plugins/labeledgroupedtests/LabeledTestGroupConfiguration/config.jelly
+++ b/src/main/resources/hudson/plugins/labeledgroupedtests/LabeledTestGroupConfiguration/config.jelly
@@ -1,0 +1,46 @@
+<!--
+The MIT License
+
+Copyright (c) 2010 Yahoo!, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+
+    <j:invokeStatic className="hudson.plugins.labeledgroupedtests.LabeledTestResultGroupPublisher" method="getTestResultParsers" var="parsers" />
+
+                    <f:entry title="Report File Mask" field="testResultFileMask">
+                        <f:textbox />
+                    </f:entry>
+                    <f:entry name="parserClassName" title="Result Format" field="parserClassName">
+                        <select name="parserClassName">
+                            <j:forEach var="parser" items="${parsers}">
+                                <f:option value="${parser.class.name}" selected="${parser.class.name==it.parserClassName}">${parser.displayName}</f:option>
+                            </j:forEach>
+                        </select>
+                    </f:entry>
+                    <f:entry title="Group Label" field="label">
+                        <f:textbox />
+                    </f:entry>
+                <f:entry title="">
+                    <div align="right">
+                        <f:repeatableDeleteButton value="Delete Test Result Group"/>
+                    </div>
+                </f:entry>
+</j:jelly>

--- a/src/main/resources/hudson/plugins/labeledgroupedtests/LabeledTestResultGroupPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/labeledgroupedtests/LabeledTestResultGroupPublisher/config.jelly
@@ -21,41 +21,12 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
 
-    <j:invokeStatic className="hudson.plugins.labeledgroupedtests.LabeledTestResultGroupPublisher" method="getTestResultParsers" var="parsers" />
-    <j:invokeStatic className="hudson.plugins.labeledgroupedtests.LabeledTestResultGroupPublisher" method="getPhases" var="phases"/>
-
-    <f:entry>
-        <f:repeatable name="configs" var="curConfig" items="${instance.configs}"
-                      add="Add Test Report Group" minimum="1">
-            <table width="100%">
-                <f:entry title="">
-                    <f:entry title="Report File Mask">
-                        <f:textbox name="testResultFileMask" value="${curConfig.testResultFileMask}" ></f:textbox>
-                        <f:entry title="Result Format" name="format">
-                            <select name="parserClassName">
-                                <j:forEach var="parser" items="${parsers}">
-                                    <f:option value="${parser.class.name}" selected="${parser.class.name==curConfig.parserClassName}">${parser.displayName}</f:option>
-                                </j:forEach>
-                            </select>
-                        </f:entry>
-
-                        <f:entry title="Group Label">
-                            <select name="label">
-                                <j:forEach var="phase" items="${phases}">
-                                    <f:option value="${phase}"  selected="${phase==curConfig.label}">${phase}</f:option>
-                                </j:forEach>
-                            </select>
-                        </f:entry>
-
-                    </f:entry>
-                </f:entry>
-                <f:entry title="">
-                    <div align="right">
-                        <f:repeatableDeleteButton value="Delete Test Result Group"/>
-                    </div>
-                </f:entry>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <f:entry field="configs">
+        <f:repeatable field="configs" add="Add Test Report Group" >
+            <table style="width:100%">
+              <st:include page="config.jelly" class="${descriptor.clazz}" />
             </table>
         </f:repeatable>
     </f:entry>


### PR DESCRIPTION
Changed the test label from a finite selection to a customizable text label. This has been tested backwards-compatible; when upgrading to the new plugin, the old names ("unit", "integration", etc.) will remain in the label textbox.