### PR TITLE
[FIXED JENKINS-20979] Do not block on build step monitor. Fixes the serialization issue in concurrently running builds.

### DIFF
--- a/src/main/java/hudson/plugins/labeledgroupedtests/LabeledTestResultGroupPublisher.java
+++ b/src/main/java/hudson/plugins/labeledgroupedtests/LabeledTestResultGroupPublisher.java
@@ -64,7 +64,7 @@ public class LabeledTestResultGroupPublisher extends Recorder implements Seriali
      * Declares the scope of the synchronization monitor this {@link hudson.tasks.BuildStep} expects from outside.
      */
     public BuildStepMonitor getRequiredMonitorService() {
-        return BuildStepMonitor.BUILD;
+        return BuildStepMonitor.NONE;
     }
 
     public MatrixAggregator createAggregator(MatrixBuild build, Launcher launcher, BuildListener listener) {


### PR DESCRIPTION
This is consistent with the similar fixes in other jenkins plugins. EP-97

Authored by: Slava Gurevich <slavag@altiscale.com>, Adam Berry <adamb@altiscale.com>