### PR TITLE
[JENKINS-30711] Fixed incorrect reference to parserClassName in options.

### DIFF
--- a/src/main/resources/hudson/plugins/labeledgroupedtests/LabeledTestGroupConfiguration/config.jelly
+++ b/src/main/resources/hudson/plugins/labeledgroupedtests/LabeledTestGroupConfiguration/config.jelly
@@ -31,7 +31,7 @@ THE SOFTWARE.
                     <f:entry name="parserClassName" title="Result Format" field="parserClassName">
                         <select name="parserClassName">
                             <j:forEach var="parser" items="${parsers}">
-                                <f:option value="${parser.class.name}" selected="${parser.class.name==it.parserClassName}">${parser.displayName}</f:option>
+                                <f:option value="${parser.class.name}" selected="${parser.class.name==instance.parserClassName}">${parser.displayName}</f:option>
                             </j:forEach>
                         </select>
                     </f:entry>


### PR DESCRIPTION
Fixes broken loading of parser configuration.