### PR TITLE
Adding pipeline support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>junit</artifactId>
-            <version>1.0</version>
+            <version>1.2</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,10 +27,9 @@ THE SOFTWARE.
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.jvnet.hudson.plugins</groupId>
+        <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.343</version>
-        <relativePath>../pom.xml</relativePath>
+        <version>1.577</version>
     </parent>
 
     <artifactId>labeled-test-groups-publisher</artifactId>
@@ -62,10 +61,14 @@ THE SOFTWARE.
 
     <dependencies>
         <dependency>
-            <groupId>org.jvnet.hudson.main</groupId>
-            <artifactId>hudson-core</artifactId>
-            <version>${hudson.version}</version>
-            <scope>provided</scope>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>junit</artifactId>
+            <version>1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>matrix-project</artifactId>
+            <version>1.0</version>
         </dependency>
     </dependencies>
 
@@ -88,7 +91,7 @@ THE SOFTWARE.
   <distributionManagement>
     <repository>
       <id>maven.jenkins-ci.org</id>
-      <url>http://maven.jenkins-ci.org:8081/content/repositories/releases/</url>
+      <url>https://repo.jenkins-ci.org/releases/</url>
     </repository>
   </distributionManagement>
 

--- a/src/main/java/hudson/plugins/labeledgroupedtests/LabeledTestResultGroup.java
+++ b/src/main/java/hudson/plugins/labeledgroupedtests/LabeledTestResultGroup.java
@@ -234,9 +234,9 @@ public class LabeledTestResultGroup extends MetaTabulatedResult {
     }
     
     @Override
-    public AbstractBuild<?, ?> getOwner() {
+    public Run<?, ?> getRun() {
         if (parent == null) return null;
-        return parent.getOwner();
+        return parent.getRun();
     }
 
     @Override
@@ -286,13 +286,13 @@ public class LabeledTestResultGroup extends MetaTabulatedResult {
             LOGGER.warning("Can't getPreviousResult; parent was null."); 
             return null;
         }
-        AbstractBuild<?,?> b = parent.getOwner();
+        Run<?,?> b = parent.getRun();
         if (b==null) {
-            LOGGER.warning("Can't getPreviousResult; parent.getOwner() was null");
+            LOGGER.warning("Can't getPreviousResult; parent.getRun() was null");
             return null;
         }
         while(true) {
-            AbstractBuild<?,?> n = b;
+            Run<?,?> n = b;
             b = b.getPreviousBuild();
             if(b==null) {
                 if (n.getNumber()!=1) { 

--- a/src/main/java/hudson/plugins/labeledgroupedtests/MetaLabeledTestResultGroup.java
+++ b/src/main/java/hudson/plugins/labeledgroupedtests/MetaLabeledTestResultGroup.java
@@ -212,7 +212,7 @@ public class MetaLabeledTestResultGroup extends MetaTabulatedResult {
     public MetaLabeledTestResultGroup getPreviousResult() {
         // TODO: consider caching
         if (parentAction == null) return null;
-        AbstractBuild<?,?> b = parentAction.owner;
+        Run<?, ?> b = parentAction.run;
         while(true) {
             b = b.getPreviousBuild();
             if(b==null)
@@ -365,9 +365,10 @@ public class MetaLabeledTestResultGroup extends MetaTabulatedResult {
         return (totalCount != 0);
     }
 
-    public AbstractBuild<?, ?> getOwner() {
+    @Override
+    public Run<?, ?> getRun() {
         if (parentAction != null)
-            return parentAction.owner;
+            return parentAction.run;
         else
             return null;
     }

--- a/src/main/java/hudson/plugins/labeledgroupedtests/MetaLabeledTestResultGroupAction.java
+++ b/src/main/java/hudson/plugins/labeledgroupedtests/MetaLabeledTestResultGroupAction.java
@@ -24,20 +24,14 @@
 package hudson.plugins.labeledgroupedtests;
 
 import com.thoughtworks.xstream.XStream;
-import hudson.Functions;
 import hudson.XmlFile;
-import hudson.model.AbstractBuild;
-import hudson.model.BuildListener;
-import hudson.tasks.junit.CaseResult;
-import hudson.tasks.junit.SuiteResult;
-import hudson.tasks.junit.TestResult;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 import hudson.tasks.test.AbstractTestResultAction;
 import hudson.tasks.test.TestObject;
-import hudson.util.HeapSpaceStringConverter;
 import hudson.util.XStream2;
 import org.kohsuke.stapler.StaplerProxy;
 
-import javax.rmi.CORBA.Util;
 import java.io.File;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
@@ -70,8 +64,9 @@ public class MetaLabeledTestResultGroupAction extends AbstractTestResultAction<M
      */
     private transient WeakReference<MetaLabeledTestResultGroup> resultGroupReference;
 
-    public MetaLabeledTestResultGroupAction(AbstractBuild owner, MetaLabeledTestResultGroup r, BuildListener listener) {
-        super(owner);        
+    public MetaLabeledTestResultGroupAction(Run<?, ?> owner, MetaLabeledTestResultGroup r, TaskListener listener) {
+        super();
+        this.onAttached(owner);
         setResult(r, listener);
     }
 
@@ -79,7 +74,7 @@ public class MetaLabeledTestResultGroupAction extends AbstractTestResultAction<M
     /**
      * Store the data to a separate file, and update our cached values.
      */
-    public synchronized void setResult(MetaLabeledTestResultGroup r, BuildListener listener) {
+    public synchronized void setResult(MetaLabeledTestResultGroup r, TaskListener listener) {
 
         r.setParentAction(this);
 
@@ -98,7 +93,7 @@ public class MetaLabeledTestResultGroupAction extends AbstractTestResultAction<M
     }
 
     private XmlFile getDataFile() {
-        return new XmlFile(XSTREAM, new File(owner.getRootDir(), RESULT_DATA_FILENAME));
+        return new XmlFile(XSTREAM, new File(run.getRootDir(), RESULT_DATA_FILENAME));
     }
 
     public Object getTarget() {

--- a/src/test/java/hudson/plugins/labeledandgroupedtests/AntiDestructionTest.java
+++ b/src/test/java/hudson/plugins/labeledandgroupedtests/AntiDestructionTest.java
@@ -26,7 +26,7 @@ package hudson.plugins.labeledandgroupedtests;
 import com.thoughtworks.xstream.XStream;
 import hudson.model.Items;
 import hudson.tasks.junit.JUnitResultArchiver;
-import hudson.util.DescribableList;
+import hudson.tasks.junit.TestDataPublisher;
 import org.jvnet.hudson.test.HudsonTestCase;
 
 import java.util.List;
@@ -62,7 +62,7 @@ public class AntiDestructionTest extends HudsonTestCase {
 
 
         boolean emptyTDPs = false;
-        DescribableList testDataPublishers = reloadedArchiver.getTestDataPublishers();
+        List<? extends TestDataPublisher> testDataPublishers = reloadedArchiver.getTestDataPublishers();
         try {
             if (testDataPublishers==null) {
                 emptyTDPs = true;

--- a/src/test/java/hudson/plugins/labeledandgroupedtests/CombinationOfParsersAndLabelsTest.java
+++ b/src/test/java/hudson/plugins/labeledandgroupedtests/CombinationOfParsersAndLabelsTest.java
@@ -29,8 +29,7 @@ import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.html.HtmlTable;
 import com.gargoylesoftware.htmlunit.html.HtmlAnchor;
 import com.gargoylesoftware.htmlunit.Page;
-import hudson.tasks.test.*;
-import hudson.tasks.junit.*;
+
 import hudson.tasks.junit.PackageResult;
 import hudson.model.*;
 import hudson.plugins.labeledgroupedtests.MetaLabeledTestResultGroupAction;
@@ -38,6 +37,8 @@ import hudson.plugins.labeledgroupedtests.MetaLabeledTestResultGroup;
 import hudson.plugins.labeledgroupedtests.LabeledTestResultGroup;
 import hudson.slaves.DumbSlave;
 import hudson.tasks.test.TestResult;
+import jenkins.model.Jenkins;
+
 import org.jvnet.hudson.test.HudsonTestCase;
 import org.jvnet.hudson.test.recipes.LocalData;
 
@@ -46,8 +47,6 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 
 /**
  * Exercise a project with a known configuration using multiple test
@@ -135,7 +134,7 @@ public class CombinationOfParsersAndLabelsTest extends EnhancedHudsonTestCase {
         // Look for a MetaLabeledTestResultGroup at the top level
         MetaLabeledTestResultGroup result = action.getResultAsTestResultGroup();
         assertNotNull("we should have a non-null result group", result);
-        AbstractBuild<?,?> owner = result.getOwner();
+        Run<?,?> owner = result.getRun();
         assertNotNull("the result should have a non-null owner", owner);
 
         
@@ -369,7 +368,7 @@ public class CombinationOfParsersAndLabelsTest extends EnhancedHudsonTestCase {
      */
      private void reloadHudson() throws NoSuchMethodException,
              IllegalAccessException, InvocationTargetException {
-         Method m = Hudson.class.getDeclaredMethod("loadTasks");
+         Method m = Jenkins.class.getDeclaredMethod("loadTasks");
          m.setAccessible(true);
          m.invoke(hudson);
      }

--- a/src/test/java/hudson/plugins/labeledandgroupedtests/ConfigurationConversionTest.java
+++ b/src/test/java/hudson/plugins/labeledandgroupedtests/ConfigurationConversionTest.java
@@ -91,7 +91,7 @@ public class ConfigurationConversionTest extends TestCase {
         try {
             LabeledTestResultGroupPublisher publisher = (LabeledTestResultGroupPublisher) xmlFile.read();
             fail("exception not encountered!");
-        } catch (IOException2 e) {
+        } catch (IOException e) {
             if (!ConversionException.class.equals(e.getCause().getClass())) {
                 fail("wrong cause"); 
             }

--- a/src/test/java/hudson/plugins/labeledandgroupedtests/CountingTest.java
+++ b/src/test/java/hudson/plugins/labeledandgroupedtests/CountingTest.java
@@ -124,7 +124,7 @@ public class CountingTest extends EnhancedHudsonTestCase {
             }
             HudsonTestCase.WebClient wc = new HudsonTestCase.WebClient();
 
-            // First check that for the ones we just ran, it always says (1 failure / ±0) on the build summary page
+            // First check that for the ones we just ran, it always says (1 failure / Â±0) on the build summary page
 
             HtmlPage projectPage = wc.goTo(project.getUrl());
             String pageAsText = projectPage.asXml();
@@ -136,7 +136,7 @@ public class CountingTest extends EnhancedHudsonTestCase {
             // Ugh. The +/- character behaves differently on the mac than on unix.
             // This test passes on the mac, fails on unix, so, sadly, I'm going to
             // do some obnoxious workaround.
-            String plusOrMinusSymbol = " ±";
+            String plusOrMinusSymbol = " Â±";
 
 
             String xPathToMainPanel = "//td[@id='main-panel']";


### PR DESCRIPTION
Implementation of SimpleBuildStep to allow usage in pipeline with following syntax :

```
step([$class: 'LabeledTestResultGroupPublisher', configs: [[
    parserClassName: 'hudson.tasks.junit.JUnitParser', testResultFileMask: 'surefire-reports/TEST-*.xml', label: 'Selenium'
]]])
```

Require Jenkins 1.577 et Junit plugin 1.2

Inspired from https://github.com/jenkinsci/junit-plugin/commit/4ba5a491583157a90bfd472db5f657a60bb0c38e