### PR TITLE
Remove usage of deprecated IOException2

### DIFF
--- a/src/test/java/hudson/plugins/labeledandgroupedtests/ConfigurationConversionTest.java
+++ b/src/test/java/hudson/plugins/labeledandgroupedtests/ConfigurationConversionTest.java
@@ -34,7 +34,6 @@ import hudson.plugins.labeledgroupedtests.LabeledTestGroupsPublisherPlugin;
 import hudson.tasks.Publisher;
 import hudson.util.StringConverter2;
 import hudson.util.XStream2;
-import hudson.util.IOException2;
 import junit.framework.TestCase;
 
 import java.io.File;
@@ -54,7 +53,7 @@ import java.util.List;
 public class ConfigurationConversionTest extends TestCase {
 
     private XStream XSTREAM = new XStream2();
-    
+
     private void registerConverters() {
         XSTREAM.alias("project",FreeStyleProject.class);
         LabeledTestGroupsPublisherPlugin.registerWithXStream(XSTREAM);
@@ -93,14 +92,14 @@ public class ConfigurationConversionTest extends TestCase {
             fail("exception not encountered!");
         } catch (IOException e) {
             if (!ConversionException.class.equals(e.getCause().getClass())) {
-                fail("wrong cause"); 
+                fail("wrong cause");
             }
         }
     }
 
 
 
- 
+
     private void checkConfigsForCppAndJunit(List<LabeledTestGroupConfiguration> configs, String expectedCppFileMask, String expectedJUnitFileMask) {
         // One of the parsers should be cpp
         // One should be Junit


### PR DESCRIPTION
## Remove usage of deprecated IOException2

Removes usage of deprecated `hudson.util.IOException2` by replacing it with `java.io.IOException`

### Testing done

None, rely on `ci.jenkins.io` to test it.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
